### PR TITLE
Updates to support default branch name changes

### DIFF
--- a/add-content.md
+++ b/add-content.md
@@ -11,9 +11,9 @@ Prior to adding or editing content, all additions and changes must be approved a
 2. Create a branch called `development` in the target repository.
 3. Commit new content or changes to the `development` branch.
 4. Review the changes on the RAC development server at docs.dev.rockarch.org. When a repository is first created, it has to be manually added to the development server. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet).
-5. Submit a pull request to merge `development` to the `master` branch of the GitHub repo.
+5. Submit a pull request to merge `development` to the `base` branch of the GitHub repo.
 6. As per the *Content Approval Policy*, each pull request will be reviewed by the relevant Assistant Director and the Director of Archives, as necessary. If a determination is made to either convert documentation from public to private, or to remove it completely, the Assistant Director for Digital Programs or any other RAC employee with administrative access to the RAC GitHub account should be notified to enable this action.
-7. Once a pull request is reviewed and approved, merge the branch into the `master` branch where it will be incorporated into docs.rockarch.org. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet) for directions on adding the master branch to the production server.
+7. Once a pull request is reviewed and approved, merge the branch into the `base` branch where it will be incorporated into docs.rockarch.org. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet) for directions on adding the base branch to the production server.
 
 ## Required Elements
 
@@ -64,7 +64,7 @@ To add a license after the repo is created:
 
 ###  \_config.yml
 
-Create a file called `_config.yml`. See the [docs-build README](https://github.com/RockefellerArchiveCenter/docs-build/blob/master/README.md#repository-configuration) for the specific variables required in `_config.yml`. This configuration file provides information to determine whether the documentation in the repo is designated as public or private, the title and description, associated tags, and pages information that is used to create the side navigation table of contents for each set of documentation.
+Create a file called `_config.yml`. See the [docs-build README](https://github.com/RockefellerArchiveCenter/docs-build/blob/base/README.md#repository-configuration) for the specific variables required in `_config.yml`. This configuration file provides information to determine whether the documentation in the repo is designated as public or private, the title and description, associated tags, and pages information that is used to create the side navigation table of contents for each set of documentation.
 
 * The title in the config file should match the title in `index.md`, for example “Collection Policy” or “Guide to Processing Collections”.
 * Designate the documentation as private using `public: false` until it has been approved for public access by the Director of Archives and President.

--- a/add-content.md
+++ b/add-content.md
@@ -9,7 +9,7 @@ Prior to adding or editing content, all additions and changes must be approved a
 
 1. Create a new RAC GitHub repository for the documentation if one does not exist using the [docs-template](https://github.com/RockefellerArchiveCenter/docs-template) repository template. Contact an RAC employee with administrative access to the RAC GitHub to enable this action. See [Create a Repo](/docs-guide/using-github#create-a-repo).
 2. Create a branch called `development` in the target repository.
-3. Commit new content or changes to the `development` branch.
+3. Commit new content or changes to the `development` branch using short, descriptive commit messages.
 4. Review the changes on the RAC development server at docs.dev.rockarch.org. When a repository is first created, it has to be manually added to the development server. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet) or ask for help.
 5. Submit a pull request to merge `development` to the `base` branch of the GitHub repo.
 6. As per the *Content Approval Policy*, each pull request will be reviewed by the relevant Assistant Director and the Director of Archives, as necessary. If a determination is made to either convert documentation from public to private, or to remove it completely, the Assistant Director for Digital Programs or any other RAC employee with administrative access to the RAC GitHub account should be notified to enable this action.

--- a/add-content.md
+++ b/add-content.md
@@ -7,10 +7,10 @@ title: "Documentation Site Guide | Add and Edit Content"
 
 Prior to adding or editing content, all additions and changes must be approved as specified in the [Rockefeller Archive Center Documentation Site Content Approval Policy](https://docs.rockarch.org/docs-policy/). All public content must be approved by the Director of Archives and President.
 
-1. Create a new RAC GitHub repository for the documentation if one does not exist. Contact a RAC employee with administrative access to the RAC GitHub to enable this action. See [Create a Repo](/docs-guide/using-github#create-a-repo).
+1. Create a new RAC GitHub repository for the documentation if one does not exist using the [docs-template](https://github.com/RockefellerArchiveCenter/docs-template) repository template. Contact an RAC employee with administrative access to the RAC GitHub to enable this action. See [Create a Repo](/docs-guide/using-github#create-a-repo).
 2. Create a branch called `development` in the target repository.
 3. Commit new content or changes to the `development` branch.
-4. Review the changes on the RAC development server at docs.dev.rockarch.org. When a repository is first created, it has to be manually added to the development server. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet).
+4. Review the changes on the RAC development server at docs.dev.rockarch.org. When a repository is first created, it has to be manually added to the development server. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet) or ask for help.
 5. Submit a pull request to merge `development` to the `base` branch of the GitHub repo.
 6. As per the *Content Approval Policy*, each pull request will be reviewed by the relevant Assistant Director and the Director of Archives, as necessary. If a determination is made to either convert documentation from public to private, or to remove it completely, the Assistant Director for Digital Programs or any other RAC employee with administrative access to the RAC GitHub account should be notified to enable this action.
 7. Once a pull request is reviewed and approved, merge the branch into the `base` branch where it will be incorporated into docs.rockarch.org. See the [Documentation Site Info Sheet](http://docs.rockarch.org/systems-info-sheets/documentation-site-info-sheet) for directions on adding the base branch to the production server.
@@ -53,14 +53,7 @@ Every GitHub repository requires a `README.md` file that includes information ab
 
 All RAC documentation that is shared publicly on this platform will be made available under a [Creative Commons Zero](https://creativecommons.org/publicdomain/zero/1.0/) (CC0) public domain dedication, and all project-associated code is made available on the RAC organizational GitHub under an [MIT License](https://opensource.org/licenses/MIT). For public content, choose a CC0 License for the GitHub repository. Do not select a license for private content.
 
-
-To add a license after the repo is created:
-
-1. Navigate to the repository page on GitHub
-2. Choose "Create new file"
-3. Name the file `LICENSE.md.`
-4. Copy the Markdown formatted text of the [CC0 1.0 Universal License](https://github.com/idleberg/Creative-Commons-Markdown/edit/master/4.0/zero.markdown) into the new file.
-5. Commit the new file.
+The template repository already includes the CC0 License, but if the content is private (for internal RAC staff use only), remove `LICENSE.md` and the reference to it in `README.md`.
 
 ###  \_config.yml
 

--- a/using-github.md
+++ b/using-github.md
@@ -29,9 +29,10 @@ To work with GitHub:
 
 [Create a Repo Instructions](https://help.github.com/articles/create-a-repo/) from GitHub.
 
-1. Designate the owner as the Rockefeller Archive Center.
-2. Format the name using lowercase letters and dashes between words "short-name" (e.g. processing-manual).
-3. Add a short description of the documentation.
-4. Choose to make the repo public or private based on its pre-approved designation (see the* Rockefeller Archive Center Documentation Site Content Approval Policy*). The designation must be approved by the RAC Assistant Director for the relevant function area, and documentation that is made publicly available must also be approved by the Director of Archives.
-5. [Add a README file](/docs-guide/add-content#readme) as specified in thi documentation.
-6. [Add a License](/docs-guide/add-content#license) as specified in this documentation.
+1. Choose a template: use `RockefellerArchiveCenter/docs-template`.
+2. Designate the owner as the Rockefeller Archive Center.
+3. Format the name using lowercase letters and dashes between words "short-name" (e.g. processing-manual).
+4. Add a short description of the documentation.
+5. Choose to make the repo public or private based on its pre-approved designation (see the [Rockefeller Archive Center Documentation Site Content Approval Policy](http://docs.rockarch.org/docs-policy/)). The designation must be approved by the RAC Assistant Director for the relevant function area, and documentation that is made publicly available must also be approved by the Director of Archives.
+6. A [README file](/docs-guide/add-content#readme), as specified in this documentation, is included in the template.
+7. A [License](/docs-guide/add-content#license), as specified in this documentation, is included in the template.

--- a/using-github.md
+++ b/using-github.md
@@ -15,6 +15,8 @@ To add and manage files in a GitHub repository, become familiar with the princip
 
 [Learn Git](https://www.codecademy.com/learn/learn-git). Code Academy course to learn the basics of the Git workflow
 
+[A Beginner’s Guide to Git — How to Write a Good Commit Message](https://www.freecodecamp.org/news/a-beginners-guide-to-git-how-to-write-a-good-commit-message/). Short post on the basics of writing meaningful commit messages.
+
 ## Get Started with GitHub
 
 To work with GitHub:


### PR DESCRIPTION
Fixes #10
Updates the guide to reflect changing the repository default branch to be `base` instead of `master`, as well as the implementation of a [repository template](https://github.com/RockefellerArchiveCenter/docs-template).

Also adds a note and a resource related to git commit messages, which fixes #11 .